### PR TITLE
Functionality for issue #1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,16 @@
 mod structs;
 mod filereader;
+
+use std::env;
+
 fn main() {
     println!("Hello, world!");
-    let path = "map.txt";
+    let args: Vec<String> = env::args().collect();
+    if (args.len() != 2) {
+        panic!("Wrong arguments: {args:?}, expected 1 for path got {}",
+            args.len() - 1);
+    }
+    let path = args[1].as_str();
     let (meta, map) = filereader::filereader::load_map_data_from_file(path);
     println!("Rover Map: {map:?}");
     println!("-------------------------");


### PR DESCRIPTION
Enables reading of a rudimentary map file.

Example Usage:
` target/debug/roverpath map.txt` from root of repo